### PR TITLE
ci: pin actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,20 +3,26 @@ on:
   push:
 jobs:
   golangci-lint:
+    name: golangci-lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        with:
+          skip-cache: true
   test:
+    name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
       - name: Run tests


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/test.yaml` file. The changes primarily involve updating the versions of various GitHub Actions used in the workflow.

Updates to GitHub Actions workflow configuration:

* Added `name` fields for the `golangci-lint` and `test` jobs to improve clarity in the workflow logs.
* Updated `actions/checkout` to `v4.2.2` for both `golangci-lint` and `test` jobs to ensure the latest stable version is used.
* Updated `actions/setup-go` to `v5.4.0` for both `golangci-lint` and `test` jobs to ensure compatibility with the latest Go versions.
* Updated `golangci/golangci-lint-action` to `v6.5.1` and added `skip-cache: true` to ensure the latest linter is used without caching issues.
* Added `permissions` section to the `test` job to explicitly define read permissions for contents, improving security and clarity.