### PR TITLE
build: bump to to v1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ShibataTakao/dailyreport
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
This pull request includes an update to the `go.mod` file to use a newer version of Go.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from 1.19 to 1.24.0.